### PR TITLE
Pause/Unpause simulation

### DIFF
--- a/src/ui/html/piston_slider.erb
+++ b/src/ui/html/piston_slider.erb
@@ -20,7 +20,7 @@ Maximum Speed (0 for continuous acceleration):
 <br>
 <input type="number" value="<%= @max_speed %>" step="0.1" onchange="set_max_speed(this.value)"> m/s
 <br><br>
-<button class="tool" onclick="unpause_simulation()">Unpause Simulation</button>
+<button class="tool" onclick="play_pause_simulation()">Play/Pause Simulation</button>
 
 <script type="text/javascript">
     function onChange(id, newValue) {
@@ -43,8 +43,8 @@ Maximum Speed (0 for continuous acceleration):
     }
 </script>
 <script type="text/javascript">
-    function unpause_simulation() {
-        sketchup.unpause_simulation()
+    function play_pause_simulation() {
+        sketchup.play_pause_simulation()
     }
 </script>
 </body>


### PR DESCRIPTION
This adds a button that can pause or unpause the simulation.
Pausing causes the force labels to appear. Unpausing can also be done if the max force was reached and a different max force was entered.