### PR TITLE
Generate IDs independently for nodes, edges and triangles

### DIFF
--- a/src/database/edge.rb
+++ b/src/database/edge.rb
@@ -15,7 +15,8 @@ class Edge < GraphObject
     @second_node.add_incident(self)
     @model_name = model_name
     @link_type = link_type
-    super(id)
+    edge_id = id.nil? ? IdManager.instance.generate_next_tag_id('edge') : id
+    super(edge_id)
   end
 
   def link_type=(type)

--- a/src/database/id_manager.rb
+++ b/src/database/id_manager.rb
@@ -7,9 +7,14 @@ class IdManager
 
   def initialize
     @last_id = 0
+    @tag_id_map = Hash.new { |h, k| h[k] = 0 }
   end
 
   def generate_next_id
     @last_id += 1
+  end
+
+  def generate_next_tag_id(tag)
+    @tag_id_map[tag] += 1
   end
 end

--- a/src/database/node.rb
+++ b/src/database/node.rb
@@ -16,7 +16,8 @@ class Node < GraphObject
     @adjacent_triangles = []    # connected triangles
     @pod_directions = {}
     @pod_constraints = {}
-    super(id)
+    node_id = id.nil? ? IdManager.instance.generate_next_tag_id('node') : id
+    super(node_id)
   end
 
   # Moves the nodes and all connected components

--- a/src/database/triangle.rb
+++ b/src/database/triangle.rb
@@ -13,7 +13,8 @@ class Triangle < GraphObject
     second_node.add_adjacent_triangle(self)
     third_node.add_adjacent_triangle(self)
     @deleted = false
-    super(id)
+    triangle_id = id.nil? ? IdManager.instance.generate_next_tag_id('triangle') : id
+    super(triangle_id)
   end
 
   def normal_towards_user


### PR DESCRIPTION
Supports ID for any kind of tag, e.g. for later usage with double hinges