### PR TITLE
Fix ordering of hinges

### DIFF
--- a/src/utility/scad_export.rb
+++ b/src/utility/scad_export.rb
@@ -135,7 +135,7 @@ class ScadExport
         b_hinges = hinges.select { |hinge| hinge.edge2 == edge }
 
         if a_hinges.size > 1 || b_hinges.size > 1
-          raise 'More than one A or B hinge around an edge.'
+          raise 'More than one A or B hinge around an edge at node ' + node.id.to_s
         end
 
         elongation = edge.first_node?(node) ? edge.first_elongation_length : edge.second_elongation_length


### PR DESCRIPTION
Make sure that when finding hinge chains, the next hinge always connects to edge2 of the current hinge.
With the previous implementation the order of a chain could change while processing the chain leading to an error during export.

Fixes export for the spider.