### PR TITLE
Add extra layer for the actuators

### DIFF
--- a/src/configuration/configuration.rb
+++ b/src/configuration/configuration.rb
@@ -11,6 +11,7 @@ module Configuration
   FORCE_LABEL_VIEW = 'Force Labels'.freeze
   FORCE_VIEW = 'Forces'.freeze
   HINGE_VIEW = 'Hinge lines'.freeze
+  ACTUATOR_VIEW = 'Actuators'.freeze
 
   # UI Dialog Properties
   HTML_DIALOG = {

--- a/src/models/physics_link_model.rb
+++ b/src/models/physics_link_model.rb
@@ -24,6 +24,7 @@ class PhysicsLinkModel
                                                       diameter, 12)
     face = definition.entities.add_face(circle_edgearray)
     face.pushpull(-2 * @length / 3, false)
+    definition.entities.each{ |entity| entity.layer = Configuration::ACTUATOR_VIEW }
     definition
   end
 

--- a/src/utility/project_helper.rb
+++ b/src/utility/project_helper.rb
@@ -57,6 +57,10 @@ module ProjectHelper
       layers.add(Configuration::HUB_VIEW)
     end
 
+    unless layers[Configuration::ACTUATOR_VIEW]
+      layers.add(Configuration::ACTUATOR_VIEW)
+    end
+
     unless layers[Configuration::DRAW_TOOLTIPS_VIEW]
       layers.add(Configuration::DRAW_TOOLTIPS_VIEW)
     end


### PR DESCRIPTION
Currently I have the bug, that when you start sketchup new, and add the first actuator, it will be made invisible if you disable layer0, however for the next actuators this doesn't happen. 
Also if you select something in Sketchup in previous, this won't happen, so seems like a bug with weird behaviour at the startup.