### PR TITLE
make it possible to change a link type to bottle link

### DIFF
--- a/src/tools/actuator_tool.rb
+++ b/src/tools/actuator_tool.rb
@@ -1,8 +1,8 @@
-require 'src/tools/physics_link_tool.rb'
+require 'src/tools/link_tool.rb'
 
 # Tool that places an actuator between two hubs or turns an existing edge into
 # an actuator
-class ActuatorTool < PhysicsLinkTool
+class ActuatorTool < LinkTool
   def initialize(ui)
     super(ui, 'actuator')
   end

--- a/src/tools/bottle_link_tool.rb
+++ b/src/tools/bottle_link_tool.rb
@@ -2,50 +2,8 @@ require 'src/tools/tool.rb'
 require 'src/utility/mouse_input.rb'
 
 # Creates a bottle link between two nodes
-class BottleLinkTool < Tool
-  def initialize(_ui)
-    super
-    @mouse_input = MouseInput.new(snap_to_nodes: true)
-  end
-
-  def activate
-    reset
-  end
-
-  def deactivate(view)
-    reset
-    super
-  end
-
-  def onLButtonDown(_flags, x, y, view)
-    # is it the first time the mouse goes down
-    if @first_position.nil?
-      Sketchup.active_model.start_operation('Create Bottle Link', true)
-      @first_position = @mouse_input.update_positions(view, x, y)
-      Sketchup.active_model.commit_operation
-    else
-      second_position =
-        @mouse_input
-        .update_positions(view, x, y,
-                          point_on_plane_from_camera_normal: @first_position)
-
-      puts 'Create single bottle link'
-      Sketchup.active_model.start_operation('Build Bottle Link', true)
-      Graph.instance.create_edge_from_points(@first_position,
-                                             second_position)
-      Sketchup.active_model.commit_operation
-      reset
-    end
-  end
-
-  def onMouseMove(_flags, x, y, view)
-    @mouse_input.update_positions(view, x, y)
-  end
-
-  private
-
-  def reset
-    @mouse_input.soft_reset
-    @first_position = nil
+class BottleLinkTool < LinkTool
+  def initialize(ui)
+    super(ui, 'bottle_link')
   end
 end

--- a/src/tools/generic_physics_link_tool.rb
+++ b/src/tools/generic_physics_link_tool.rb
@@ -1,8 +1,8 @@
-require 'src/tools/physics_link_tool.rb'
+require 'src/tools/link_tool.rb'
 
 # Tool that places a generic link (i.e. a link that can be used with a custom
 # force function) between two hubs or turns an existing edge into a generic link
-class GenericPhysicsLinkTool < PhysicsLinkTool
+class GenericPhysicsLinkTool < LinkTool
   def initialize(ui)
     super(ui, 'generic')
   end

--- a/src/tools/link_tool.rb
+++ b/src/tools/link_tool.rb
@@ -5,7 +5,7 @@ require 'src/algorithms/rigidity_tester.rb'
 require 'src/simulation/thingy_rotation.rb'
 
 # superclass for all links that can move
-class PhysicsLinkTool < Tool
+class LinkTool < Tool
   MIN_ANGLE_DEVIATION = 0.05
 
   def initialize(ui, link_type)

--- a/src/tools/spring_tool.rb
+++ b/src/tools/spring_tool.rb
@@ -1,7 +1,7 @@
-require 'src/tools/physics_link_tool.rb'
+require 'src/tools/link_tool.rb'
 
 # creates a gas spring-type link
-class SpringTool < PhysicsLinkTool
+class SpringTool < LinkTool
   def initialize(ui)
     super(ui, 'spring')
   end


### PR DESCRIPTION
There is no reason to not use the LinkTool for bottle links, so now we do it.