### PR TITLE
prevent imported objects from floating upwards slightly

### DIFF
--- a/src/utility/json_import.rb
+++ b/src/utility/json_import.rb
@@ -149,7 +149,7 @@ module JsonImport
         z = node['z'].to_f.mm
         point = Geom::Point3d.new(x, y, z)
         if first
-          position.z = z_height
+          position.z = z_height + Configuration::BALL_HUB_RADIUS
           translation = point.vector_to(position)
           first = false
         end


### PR DESCRIPTION
The Hub radius was not taken into account during the JSON import, so the object was placed 14mm into the ground, causing it to rise up 14mm upon simulation start. This probably didn't have any effect on the simulation, but is fixed now, nonetheless.