### PR TITLE
do not reset edges when node export starts

### DIFF
--- a/src/export/node_export_algorithm.rb
+++ b/src/export/node_export_algorithm.rb
@@ -20,7 +20,6 @@ class NodeExportAlgorithm
 
   def run
     edges = Graph.instance.edges.values
-    edges.each(&:reset)
 
     static_groups = StaticGroupAnalysis.find_static_groups
     static_groups.select! { |group| group.size > 1 }


### PR DESCRIPTION
@p-otto does this have any implications? I don't really see why we have to recreate the edges here.