### PR TITLE
fix merging of hubs using the move tool

### DIFF
--- a/src/algorithms/relaxation.rb
+++ b/src/algorithms/relaxation.rb
@@ -55,6 +55,8 @@ class Relaxation
 
   def fix_node(node)
     @fixed_nodes << node
+    add_edges(node.incidents)
+    update_incident_edges(node)
     self
   end
 

--- a/src/database/edge.rb
+++ b/src/database/edge.rb
@@ -108,8 +108,10 @@ class Edge < GraphObject
   def exchange_node(current_node, new_node)
     if current_node == @first_node
       @first_node = new_node
+      link.first_node = new_node
     elsif current_node == @second_node
       @second_node = new_node
+      link.second_node = new_node
     else
       raise "#{current_node} not in nodes"
     end

--- a/src/database/graph.rb
+++ b/src/database/graph.rb
@@ -192,9 +192,9 @@ class Graph
   # This removes all objects with deleted instances
   # Call this prior to exporting, importing, or starting simulation
   def cleanup
-    @edges.select! { |_, e| e.check_if_valid }
-    @nodes.select! { |_, e| e.check_if_valid }
-    @triangles.select! { |_, e| e.check_if_valid }
+    @edges.select! { |_, e| !e.nil? || e.check_if_valid }
+    @nodes.select! { |_, e| !e.nil? || e.check_if_valid }
+    @triangles.select! { |_, e| !e.nil? || e.check_if_valid }
   end
 
   #

--- a/src/database/node.rb
+++ b/src/database/node.rb
@@ -159,6 +159,7 @@ class Node < GraphObject
     @adjacent_triangles -= merged_adjacent_triangles
 
     delete
+    Graph.instance.cleanup
   end
 
   def find_pod(direction)

--- a/src/sketchup_objects/link.rb
+++ b/src/sketchup_objects/link.rb
@@ -7,10 +7,9 @@ require 'src/configuration/configuration'
 
 # Link
 class Link < PhysicsSketchupObject
-  attr_accessor :joint, :model
-  attr_reader :first_elongation_length, :second_elongation_length,
-              :position, :second_position, :loc_up_vec, :first_node,
-              :second_node, :sensor_symbol, :piston_group
+  attr_accessor :joint, :model, :first_node, :second_node
+  attr_reader :first_elongation_length, :second_elongation_length, :position,
+              :second_position, :loc_up_vec, :sensor_symbol, :piston_group
 
   def initialize(first_node, second_node, edge, model_name, bottle_name: '',
                  id: nil)

--- a/src/sketchup_objects/sketchup_object.rb
+++ b/src/sketchup_objects/sketchup_object.rb
@@ -19,7 +19,7 @@ class SketchupObject
   end
 
   def check_if_valid
-    return false if @entity && !@entity.valid?
+    return false if @entity.nil? || (@entity && !@entity.valid?)
     @children.each do |child|
       return false unless child.check_if_valid
     end

--- a/src/tools/move_tool.rb
+++ b/src/tools/move_tool.rb
@@ -69,16 +69,18 @@ class MoveTool < Tool
     relaxation = Relaxation.new
 
     end_move_position = @end_position
-    unless snapped_node.nil?
-      # TODO: This is not working. For me, it is not even clear
-      # what should be done in this case
+    if snapped_node.nil?
+      relaxation.move_and_fix_node(@start_node, end_move_position)
+      relaxation.relax
+    else
+      # merging functionality
       relaxation.fix_node(snapped_node)
-      @start_node.merge_into(snapped_node)
       end_move_position = snapped_node.position
+      relaxation.move_and_fix_node(@start_node, end_move_position)
+      relaxation.relax
+      @start_node.merge_into(snapped_node)
     end
 
-    relaxation.move_and_fix_node(@start_node, end_move_position)
-    relaxation.relax
     view.invalidate
     Sketchup.active_model.commit_operation
 


### PR DESCRIPTION
Using the move tool, you can now grab a hub and pull it to another hub. They will merge. I have tested this slightly and didn't find a case where it breaks. It would be nice if you could check some edge-cases, though.