### PR TITLE
Be able to delete pods again

### DIFF
--- a/src/utility/mouse_input.rb
+++ b/src/utility/mouse_input.rb
@@ -76,6 +76,10 @@ class MouseInput
 
   def snap_to_object
     objects = []
+    if @snap_to_pods
+      pod = Graph.instance.closest_pod(@position)
+      objects.push(pod) if should_snap?(pod)
+    end
     if @snap_to_nodes
       node = Graph.instance.closest_node(@position)
       objects.push(node) if should_snap?(node)
@@ -87,10 +91,6 @@ class MouseInput
     if @snap_to_surfaces
       surface = Graph.instance.closest_triangle(@position)
       objects.push(surface) if should_snap?(surface)
-    end
-    if @snap_to_pods
-      pod = Graph.instance.closest_pod(@position)
-      objects.push(pod) if should_snap?(pod)
     end
     if @snap_to_covers
       surface = Graph.instance.closest_triangle(@position)


### PR DESCRIPTION
Put pods first in snapping hierarchy. 

It seems like the snapping area of pods and nodes is pretty similar, so right now, if a node has a pod and you use the delete tool, you first have to delete the pod, before you can select the hub.