### PR TITLE
Remove default triangle dialog, just take a random triangle on export

### DIFF
--- a/src/tools/export_file_tool.rb
+++ b/src/tools/export_file_tool.rb
@@ -11,9 +11,9 @@ class ExportFileTool < Tool
   end
 
   def activate
-    UI.messagebox('Please select a surface to become the standard surface'\
-                  ' that gets attached when added to other objects',
-                  MB_OK)
+    export_with_file_dialog
+    Sketchup.set_status_text('To export with a specific standard surface,'\
+                             'click that surface')
   end
 
   def onMouseMove(_flags, x, y, view)

--- a/src/utility/json_export.rb
+++ b/src/utility/json_export.rb
@@ -12,13 +12,14 @@ class JsonExport
 
   def self.graph_to_json(triangle = nil, animation)
     graph = Graph.instance
-    json = { distance_unit: 'mm', force_unit: 'N' }
+    json = {distance_unit: 'mm', force_unit: 'N'}
     json[:nodes] = nodes_to_hash(graph.nodes)
     json[:edges] = edges_to_hash(graph.edges)
     json[:animation] = animation
-    unless triangle.nil?
-      json[:standard_surface] = triangle.nodes_ids_towards_user
+    if triangle.nil?
+      triangle = Graph.instance.triangles.first[1] # Just take any triangle
     end
+    json[:standard_surface] = triangle.nodes_ids_towards_user
     JSON.pretty_generate(json)
   end
 


### PR DESCRIPTION
@robertkovax It is not trivially possible to check if the ctrl button is pressed on the activation of a tool. (You only get the key presses, when the tool is already activated)

Right now what happens is, that on activation, is will select a random (first created) surface, and then you can click on surfaces while the save dialog is still activated to save a version with a different standard surface. 

Do you think this is okay?