### PR TITLE
Improves Trace Visualization...

### DIFF
--- a/src/system_simulation/server/simulation_runner.rb
+++ b/src/system_simulation/server/simulation_runner.rb
@@ -183,11 +183,11 @@ class SimulationRunner
   def override_constants_string
     override_string = ''
     @identifiers_for_springs.each do |edge_id, spring_identifier|
-      override_string += "#{spring_identifier}.c='#{@constants_for_springs[edge_id]}',"
+      override_string += "#{spring_identifier}.c=#{@constants_for_springs[edge_id]},"
     end
 
     @mounted_users.each do |node_id, force|
-      override_string += "node_#{node_id}.m='#{force}',"
+      override_string += "node_#{node_id}.m=#{force},"
     end
 
     # remove last comma
@@ -197,9 +197,9 @@ class SimulationRunner
   def force_vector_string(force_vectors)
     force_vectors_string = ''
     force_vectors.each do |force_vector|
-      override_string = "node_#{force_vector['node_id']}_force_val[1]='#{force_vector['x']}'" \
-                        "node_#{force_vector['node_id']}_force_val[2]='#{force_vector['y']}'," \
-                        "node_#{force_vector['node_id']}_force_val[3]='#{force_vector['z']}'"
+      override_string = "node_#{force_vector['node_id']}_force_val[1]=#{force_vector['x']}," \
+                        "node_#{force_vector['node_id']}_force_val[2]=#{force_vector['y']}," \
+                        "node_#{force_vector['node_id']}_force_val[3]=#{force_vector['z']}"
       force_vectors_string += override_string
       force_vectors_string += ','
     end
@@ -226,9 +226,9 @@ class SimulationRunner
 
   def run_simulation(filter = '*', force_vectors = [])
     # TODO adjust sampling rate dynamically
-    overrides = "outputFormat='csv',variableFilter='#{filter}',startTime=0.3,stopTime=10,stepSize=0.01," \
+    overrides = "outputFormat=csv,variableFilter=#{filter},startTime=0.3,stopTime=10,stepSize=0.1," \
                 "#{force_vector_string(force_vectors)},#{override_constants_string}"
-    command = "./#{@model_name} -override #{overrides}"
+    command = "./#{@model_name} -override=\"#{overrides}\""
     puts(command)
     Open3.popen2e(command, chdir: @directory) do |i, o, t|
       # prints out std out of the command

--- a/src/system_simulation/server/simulation_runner.rb
+++ b/src/system_simulation/server/simulation_runner.rb
@@ -46,10 +46,11 @@ class SimulationRunner
                  suppress_compilation = false, keep_temp_dir = false)
 
     @model_name = model_name
-    #@simulation_options = "-abortSlowSimulation"
-    @simulation_options += " -lv=LOG_STATS "
+    @simulation_options = ''
+    # @simulation_options += "-abortSlowSimulation"
+    @simulation_options += ' -lv=LOG_STATS '
     # @simulation += "lv=LOG_INIT_V,LOG_SIMULATION,LOG_STATS,LOG_JAC,LOG_NLS"
-    @compilation_options = "--disableLinearTearing --maxMixedDeterminedIndex=100 -n=4"
+    @compilation_options = '--disableLinearTearing --maxMixedDeterminedIndex=100 -n=4'
 
     if suppress_compilation
       @directory = File.dirname(__FILE__)

--- a/src/system_simulation/server/simulation_runner.rb
+++ b/src/system_simulation/server/simulation_runner.rb
@@ -50,7 +50,7 @@ class SimulationRunner
     # @simulation_options += "-abortSlowSimulation"
     @simulation_options += ' -lv=LOG_STATS '
     # @simulation += "lv=LOG_INIT_V,LOG_SIMULATION,LOG_STATS,LOG_JAC,LOG_NLS"
-    @compilation_options = '--disableLinearTearing --maxMixedDeterminedIndex=100 -n=4'
+    @compilation_options = ' --maxMixedDeterminedIndex=100 -n=4'
 
     if suppress_compilation
       @directory = File.dirname(__FILE__)
@@ -228,7 +228,7 @@ class SimulationRunner
 
   def run_simulation(filter = '*', force_vectors = [])
     # TODO adjust sampling rate dynamically
-    overrides = "outputFormat=csv,variableFilter=#{filter},startTime=0.3,stopTime=10,stepSize=0.1," \
+    overrides = "outputFormat=csv,variableFilter=#{filter},startTime=0.3,stopTime=10,stepSize=0.05," \
                 "#{force_vector_string(force_vectors)},#{override_constants_string}"
     command = "./#{@model_name} #{@simulation_options} -override=\"#{overrides}\""
     puts(command)

--- a/src/system_simulation/server/simulation_runner.rb
+++ b/src/system_simulation/server/simulation_runner.rb
@@ -226,7 +226,7 @@ class SimulationRunner
 
   def run_simulation(filter = '*', force_vectors = [])
     # TODO adjust sampling rate dynamically
-    overrides = "outputFormat='csv',variableFilter='#{filter}',startTime=0.3,stopTime=10,stepSize=0.1," \
+    overrides = "outputFormat='csv',variableFilter='#{filter}',startTime=0.3,stopTime=10,stepSize=0.01," \
                 "#{force_vector_string(force_vectors)},#{override_constants_string}"
     command = "./#{@model_name} -override #{overrides}"
     puts(command)

--- a/src/system_simulation/server/simulation_runner.rb
+++ b/src/system_simulation/server/simulation_runner.rb
@@ -46,7 +46,8 @@ class SimulationRunner
                  suppress_compilation = false, keep_temp_dir = false)
 
     @model_name = model_name
-    @simulation_options = "-abortSlowSimulation"
+    #@simulation_options = "-abortSlowSimulation"
+    @simulation_options += " -lv=LOG_STATS "
     # @simulation += "lv=LOG_INIT_V,LOG_SIMULATION,LOG_STATS,LOG_JAC,LOG_NLS"
     @compilation_options = "--disableLinearTearing --maxMixedDeterminedIndex=100 -n=4"
 
@@ -228,7 +229,7 @@ class SimulationRunner
     # TODO adjust sampling rate dynamically
     overrides = "outputFormat=csv,variableFilter=#{filter},startTime=0.3,stopTime=10,stepSize=0.1," \
                 "#{force_vector_string(force_vectors)},#{override_constants_string}"
-    command = "./#{@model_name} -override=\"#{overrides}\""
+    command = "./#{@model_name} #{@simulation_options} -override=\"#{overrides}\""
     puts(command)
     Open3.popen2e(command, chdir: @directory) do |i, o, t|
       # prints out std out of the command

--- a/src/system_simulation/simulation_runner_client.rb
+++ b/src/system_simulation/simulation_runner_client.rb
@@ -4,7 +4,7 @@ require 'net/http'
 require "uri"
 require_relative 'animation_data_sample.rb'
 
-SIMULATION_RUNNER_HOST = "http://0.0.0.0:8080".freeze
+SIMULATION_RUNNER_HOST = "http://ec2-3-127-56-156.eu-central-1.compute.amazonaws.com:8080".freeze
 
 class SimulationRunnerClient
   def self.update_model(json_string)

--- a/src/system_simulation/trace_visualization.rb
+++ b/src/system_simulation/trace_visualization.rb
@@ -44,11 +44,13 @@ class TraceVisualization
       materialToSet
     end
 
+    start_position = @simulation_data[0].position_data[node_id]
     last_position = @simulation_data[0].position_data[node_id]
+    last_distance = 0
 
     @simulation_data.each_with_index do |current_data_sample, index|
       # thin out points in trace
-      next unless index % sampling_rate == 0
+      #next unless index % sampling_rate == 0
 
       @group = Sketchup.active_model.entities.add_group if @group.deleted?
       entities = @group.entities
@@ -75,6 +77,9 @@ class TraceVisualization
         p "red"
       end
       last_position = position
+      break if last_distance > distance
+
+      last_distance = distance
     end
   end
 end

--- a/src/system_simulation/trace_visualization.rb
+++ b/src/system_simulation/trace_visualization.rb
@@ -16,11 +16,11 @@ class TraceVisualization
     @alpha = 0.6
   end
 
-  def add_trace(node_ids, sampling_rate, data)
+  def add_trace(node_ids, sampling_rate, data, periods)
     reset_trace
     @simulation_data = data
     node_ids.each do |node_id|
-      add_circle_trace(node_id, sampling_rate)
+      add_circle_trace(node_id, sampling_rate, periods[node_id.to_i])
     end
   end
 
@@ -36,7 +36,9 @@ class TraceVisualization
 
   private
 
-  def add_circle_trace(node_id, sampling_rate)
+  def add_circle_trace(node_id, sampling_rate, period)
+    period ||= 3.0
+
     materials = @colors.map do |color, index|
       materialToSet = Sketchup.active_model.materials.add("VisualizationColor #{index}")
       materialToSet.color = color

--- a/src/system_simulation/trace_visualization.rb
+++ b/src/system_simulation/trace_visualization.rb
@@ -57,7 +57,7 @@ class TraceVisualization
     puts "Trace is planar: #{trace_analyzation[:is_planar]}"
 
     # Plot dots for either the period or a certain time span, if oscillation is not planar
-    trace_time_limit = trace_analyzation[:is_planar] ? period : NON_PLANAR_TRACE_DURATION
+    trace_time_limit = trace_analyzation[:is_planar] ? period.to_f : NON_PLANAR_TRACE_DURATION
 
     @simulation_data.each_with_index do |current_data_sample, index|
       # thin out points in trace
@@ -111,7 +111,7 @@ class TraceVisualization
       max_distance = distance_to_last if distance_to_last > max_distance
       is_planar = position.distance_to_plane(plane) < DISTANCE_TO_PLANE_THRESHOLD
       last_position = position
-      return { max_distance: max_distance, is_planar: is_planar } if current_data_sample.time_stamp.to_f >= period
+      return { max_distance: max_distance, is_planar: is_planar } if current_data_sample.time_stamp.to_f >= period.to_f
     end
     { max_distance: max_distance, is_planar: is_planar }
   end

--- a/src/system_simulation/trace_visualization.rb
+++ b/src/system_simulation/trace_visualization.rb
@@ -13,7 +13,7 @@ class TraceVisualization
     # Visualization parameters
     #@color = Sketchup::Color.new(72,209,204)
     @colors = [Sketchup::Color.new(255,0,0), Sketchup::Color.new(255,255,0), Sketchup::Color.new(0,255,0)]
-    @alpha = 0.2
+    @alpha = 0.6
   end
 
   def add_trace(node_ids, sampling_rate, data)
@@ -40,13 +40,14 @@ class TraceVisualization
     materials = @colors.map do |color, index|
       materialToSet = Sketchup.active_model.materials.add("VisualizationColor #{index}")
       materialToSet.color = color
-      materialToSet.alpha = @alpha
+      materialToSet.alpha = 0.6
       materialToSet
     end
 
     start_position = @simulation_data[0].position_data[node_id]
     last_position = @simulation_data[0].position_data[node_id]
     last_distance = 0
+    distance_to_start = 0
     curve_points = []
 
     @simulation_data.each_with_index do |current_data_sample, index|
@@ -57,8 +58,9 @@ class TraceVisualization
       entities = @group.entities
       position = current_data_sample.position_data[node_id]
 
-      distance = position.distance(last_position)
-      p distance
+      distance_to_last = position.distance(last_position)
+      distance_to_start = position.distance(start_position)
+      p distance_to_last
 
       edgearray = entities.add_circle(position, Geom::Vector3d.new(1,0,0), 1, 10)
       edgearray.each{|e| e.hidden=true }
@@ -66,22 +68,17 @@ class TraceVisualization
       arccurve = first_edge.curve
       face = entities.add_face(arccurve)
 
-      case distance
-      when 0.0..0.5
-        face.material = materials[2] unless face == nil
-        p "green"
-      when 0.5..5
-        face.material = materials[1] unless face == nil
-        p "orange"
-      else
-        face.material = materials[0] unless face == nil
-        p "red"
-      end
+
+      mocked_ratio = (distance_to_last / 0.7)
+
+      face.material = material_from_hsv((1 - mocked_ratio) * 130, 100, 100)
 
       curve_points << position
-      break if last_distance > distance
+      # detect turing point of oscillation
+      break if last_distance > distance_to_start
 
-      last_distance = distance
+      last_distance = distance_to_start
+      last_position = position
     end
 
     # connect points with curve
@@ -89,5 +86,30 @@ class TraceVisualization
     entities = @group.entities
     entities.add_curve(curve_points)
 
+  end
+
+  def material_from_hsv(h,s,v)
+    material = Sketchup.active_model.materials.add("VisualizationColor #{v}")
+    material.color = hsv_to_rgb(h, s, v)
+    material.alpha = 0.6
+    material
+  end
+
+  # http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically
+  def hsv_to_rgb(h, s, v)
+    h, s, v = h.to_f/360, s.to_f/100, v.to_f/100
+    h_i = (h*6).to_i
+    f = h*6 - h_i
+    p = v * (1 - s)
+    q = v * (1 - f*s)
+    t = v * (1 - (1 - f) * s)
+    r, g, b = v, t, p if h_i==0
+    r, g, b = q, v, p if h_i==1
+    r, g, b = p, v, t if h_i==2
+    r, g, b = p, q, v if h_i==3
+    r, g, b = t, p, v if h_i==4
+    r, g, b = v, p, q if h_i==5
+    # [(r*255).to_i, (g*255).to_i, (b*255).to_i]
+    Sketchup::Color.new((r*255).to_i, (g*255).to_i, (b*255).to_i)
   end
 end

--- a/src/system_simulation/trace_visualization.rb
+++ b/src/system_simulation/trace_visualization.rb
@@ -47,6 +47,7 @@ class TraceVisualization
     start_position = @simulation_data[0].position_data[node_id]
     last_position = @simulation_data[0].position_data[node_id]
     last_distance = 0
+    curve_points = []
 
     @simulation_data.each_with_index do |current_data_sample, index|
       # thin out points in trace
@@ -76,10 +77,17 @@ class TraceVisualization
         face.material = materials[0] unless face == nil
         p "red"
       end
-      last_position = position
+
+      curve_points << position
       break if last_distance > distance
 
       last_distance = distance
     end
+
+    # connect points with curve
+    @group = Sketchup.active_model.entities.add_group if @group.deleted?
+    entities = @group.entities
+    entities.add_curve(curve_points)
+
   end
 end

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -49,10 +49,11 @@ class SpringPane
 
     # update simulation data and visualizations with adjusted results
     simulate
+    update_periods
     # TODO: fix and reenable
     #put_geometry_into_equilibrium(spring_id)
     update_trace_visualization
-    update_periods
+
 
     update_dialog if @dialog
   end
@@ -95,7 +96,7 @@ class SpringPane
     @trace_visualization ||= TraceVisualization.new
     @trace_visualization.reset_trace
     # visualize every node with a mounted user
-    @trace_visualization.add_trace(mounted_users.keys.map(&:to_s), 4, @simulation_data)
+    @trace_visualization.add_trace(mounted_users.keys.map(&:to_s), 4, @simulation_data, @user_periods)
   end
 
   def put_geometry_into_equilibrium(spring_id)
@@ -206,7 +207,7 @@ class SpringPane
   end
 
   def toggle_animation
-    simulate
+    simulate unless @simulation_data
     if @animation && @animation.running
       @animation.stop
       @animation_running = false


### PR DESCRIPTION
... by:
- scaling dots according to speed
- applying HSV color scale according to speed
- plot line for whole oscillation
- plot dots only for either period (for planar oscillations) or a fixed time span (default 2 seconds)

<img width="540" alt="image" src="https://user-images.githubusercontent.com/5410949/77892838-86682880-7273-11ea-9ae6-41b2beba8a39.png">

