### PR TITLE
Adjust weights of pipes and nodes

### DIFF
--- a/src/system_simulation/server/generate_modelica_model.rb
+++ b/src/system_simulation/server/generate_modelica_model.rb
@@ -122,10 +122,13 @@ class ModelicaModelGenerator
       nodes.select {|nodeId, node| not node[:fixed]}.each{ |nodeId, node|
         primary_edge_connection_direction = get_direction(node, node[:primary_edge])
 
-        # get mass from truss fab geometry if set
-        mass = json_model['mounted_users'][nodeId.to_s] if json_model['mounted_users']
-        # fall back to default mass otherwise
-        mass ||= ModelicaConfiguration::NODE_WEIGHT_KG
+        # get added mass placed by user from truss fab geometry
+        mass = node['added_mass']
+        if json_model['mounted_users'] && json_model['mounted_users'][nodeId.to_s]
+          mass += json_model['mounted_users'][nodeId.to_s]
+        end
+        # add weight of node structure
+        mass += ModelicaConfiguration::NODE_WEIGHT_KG
 
         # Generate PointMasses
         point_mass_component = Modelica_PointMass.new(identifier_for_node_id(nodeId), mass, *node[:pos])

--- a/src/system_simulation/server/generate_modelica_model.rb
+++ b/src/system_simulation/server/generate_modelica_model.rb
@@ -84,7 +84,8 @@ class ModelicaModelGenerator
     # Phase 3.1 Generate Main Components
     edges.each { |edgeID, edge|
       edge[:name] = edge_to_modelica_name(edge)
-      edge_component = Modelica_LineForceWithMass.new(edge[:name], ModelicaConfiguration::PIPE_WEIGHT_KG, edge[:n1_orientation_fixed], edge[:n2_orientation_fixed] )
+      edge_mass = edge[:length] * ModelicaConfiguration::PIPE_WEIGHT_KG_PER_M
+      edge_component = Modelica_LineForceWithMass.new(edge[:name], edge_mass, edge[:n1_orientation_fixed], edge[:n2_orientation_fixed] )
 
       if edge['type'] == 'bottle_link'
         force_translator = Modelica_Rod.new(edge[:name] + "_rod", edge[:length].to_f, ModelicaConfiguration::STATIC_SPRING_CONSTANT)

--- a/src/system_simulation/server/modelica_configuration.rb
+++ b/src/system_simulation/server/modelica_configuration.rb
@@ -1,7 +1,7 @@
 module ModelicaConfiguration
   # Constants for Modelica model generation
-  NODE_WEIGHT_KG = 30
-  PIPE_WEIGHT_KG = 1
+  NODE_WEIGHT_KG = 0.3
+  PIPE_WEIGHT_KG_PER_M = 1
   SPRING_CONSTANT = 7000
   STATIC_SPRING_CONSTANT = 10_000_000
   POINT_MASS_GENERATION_ENABLED = true

--- a/src/utility/json_export.rb
+++ b/src/utility/json_export.rb
@@ -33,7 +33,8 @@ class JsonExport
         x: node.position.x.to_mm,
         y: node.position.y.to_mm,
         z: node.position.z.to_mm,
-        pods: node.pod_export_info
+        pods: node.pod_export_info,
+        added_mass: node.hub.mass
       }
     end
   end


### PR DESCRIPTION
Adjusts the weight values of nodes and pipes. Also makes a pipes weight dependent of its length. @ramboldio @robertkovax I used 300 grams for nodes and 1 kg per meter for pipes, you think that's fair?