### PR TITLE
Display speed and acceleration for users

### DIFF
--- a/src/system_simulation/server/simulation_runner.rb
+++ b/src/system_simulation/server/simulation_runner.rb
@@ -82,7 +82,6 @@ class SimulationRunner
     @mounted_users = mounted_users
   end
 
-
   def get_hub_time_series(force_vectors = [])
     data = []
     simulation_time = Benchmark.realtime { run_simulation(NODE_COORDINATES_FILTER, force_vectors) }
@@ -106,7 +105,7 @@ class SimulationRunner
   end
 
   def get_max_norm(id)
-    data = CSV.read(File.join(@directory, "#{@model_name}_res.csv"), :headers=>true, :converters => :numeric)
+    data = CSV.read(File.join(@directory, "#{@model_name}_res.csv"), headers: true, converters: :numeric)
     max_norm = 0
     data["#{id}[1]"].each_with_index do |value, index|
       norm = Vector.elements([value.to_f, data["#{id}[2]"][index].to_f, data["#{id}[3]"][index].to_f]).norm

--- a/src/system_simulation/server/simulation_runner_server.rb
+++ b/src/system_simulation/server/simulation_runner_server.rb
@@ -11,17 +11,17 @@ sim = nil
 post '/update_model' do
   sim = SimulationRunner.new_from_json_export(request.body.read)
   p sim
-  return ""
+  return ''
 end
 
 patch '/update_spring_constants' do
   sim.update_spring_constants(JSON.parse(request.body.read))
-  return ""
+  return ''
 end
 
 patch '/update_mounted_users' do
   sim.update_mounted_users(JSON.parse(request.body.read))
-  return ""
+  return ''
 end
 
 get '/get_user_stats/:node_id' do

--- a/src/system_simulation/server/simulation_runner_server.rb
+++ b/src/system_simulation/server/simulation_runner_server.rb
@@ -24,8 +24,8 @@ patch '/update_mounted_users' do
   return ""
 end
 
-get '/get_period/:node_id' do
-  return_message = { period: sim.get_period(params['node_id']) }
+get '/get_user_stats/:node_id' do
+  return_message = sim.get_user_stats(params['node_id'])
   return_message.to_json
 end
 

--- a/src/system_simulation/simulation_runner_client.rb
+++ b/src/system_simulation/simulation_runner_client.rb
@@ -36,7 +36,7 @@ class SimulationRunnerClient
     request = Net::HTTP::Patch.new(uri.request_uri, header)
     request.body = json_data
 
-    response = http.request(request)
+    http.request(request)
   end
 
   def self.get_user_stats(node_id)

--- a/src/system_simulation/simulation_runner_client.rb
+++ b/src/system_simulation/simulation_runner_client.rb
@@ -39,8 +39,8 @@ class SimulationRunnerClient
     response = http.request(request)
   end
 
-  def self.get_period(node_id)
-    json_response_from_server("get_period/#{node_id}")['period']
+  def self.get_user_stats(node_id)
+    json_response_from_server("get_user_stats/#{node_id}")
   end
 
   def self.get_hub_time_series(force_vectors = nil)

--- a/src/system_simulation/trace_visualization.rb
+++ b/src/system_simulation/trace_visualization.rb
@@ -41,7 +41,7 @@ class TraceVisualization
 
   private
 
-  def add_circle_trace(node_id, sampling_rate, stats)
+  def add_circle_trace(node_id, _sampling_rate, stats)
     period = stats['period']
     period ||= 3.0
 
@@ -57,9 +57,9 @@ class TraceVisualization
 
     circle_definition = create_circle_definition
 
-    @simulation_data.each_with_index do |current_data_sample, index|
+    @simulation_data.each_with_index do |current_data_sample, _index|
       # thin out points in trace
-      # next unless index % sampling_rate == 0
+      # next unless _index % _sampling_rate == 0
 
       position = current_data_sample.position_data[node_id]
 
@@ -91,12 +91,10 @@ class TraceVisualization
     @group = Sketchup.active_model.entities.add_group if @group.deleted?
     entities = @group.entities
     entities.add_curve(curve_points)
-
   end
 
   # analyzes the simulation data for certain criterions
   def analyze_trace(node_id, period)
-
     last_position = @simulation_data[0].position_data[node_id]
     max_distance = 0
     is_planar = true

--- a/src/system_simulation/trace_visualization.rb
+++ b/src/system_simulation/trace_visualization.rb
@@ -21,11 +21,11 @@ class TraceVisualization
     @alpha = 0.6
   end
 
-  def add_trace(node_ids, sampling_rate, data, periods)
+  def add_trace(node_ids, sampling_rate, data, user_stats)
     reset_trace
     @simulation_data = data
     node_ids.each do |node_id|
-      add_circle_trace(node_id, sampling_rate, periods[node_id.to_i])
+      add_circle_trace(node_id, sampling_rate, user_stats[node_id.to_i])
     end
   end
 
@@ -41,7 +41,8 @@ class TraceVisualization
 
   private
 
-  def add_circle_trace(node_id, sampling_rate, period)
+  def add_circle_trace(node_id, sampling_rate, stats)
+    period = stats['period']
     period ||= 3.0
 
     last_position = @simulation_data[0].position_data[node_id]

--- a/src/tools/place_user_tool.rb
+++ b/src/tools/place_user_tool.rb
@@ -14,6 +14,8 @@ class PlaceUserTool < Tool
       hub = obj.hub
       # TODO remove this default force value here
       hub.is_user_attached ? hub.remove_user : hub.attach_user(100)
+      # TODO: at some point springe pane should compile automatically when geometry changes
+      @ui.spring_pane.compile
       @ui.spring_pane.update_mounted_users
     end
   end

--- a/src/tools/place_user_tool.rb
+++ b/src/tools/place_user_tool.rb
@@ -1,7 +1,6 @@
 # Places a user into the geometry i.e. someone who is injecting force into the system. This tool simulates the system
 # and opens a panel that shows information and the possibility to change parameters of the springs.
 class PlaceUserTool < Tool
-
   def initialize(ui)
     super(ui)
     @mouse_input = MouseInput.new(snap_to_nodes: true)
@@ -12,7 +11,7 @@ class PlaceUserTool < Tool
     obj = @mouse_input.snapped_object
     if !obj.nil? && obj.is_a?(Node)
       hub = obj.hub
-      # TODO remove this default force value here
+      # TODO: remove this default force value here
       hub.is_user_attached ? hub.remove_user : hub.attach_user(100)
       # TODO: at some point springe pane should compile automatically when geometry changes
       @ui.spring_pane.compile

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -28,6 +28,8 @@ class SpringPane
 
     # node_id => period
     @user_periods = {}
+    @user_max_as = {}
+    @user_max_vs = {}
 
     @spring_picker = SpringPicker.instance
 
@@ -51,7 +53,7 @@ class SpringPane
 
     # update simulation data and visualizations with adjusted results
     simulate
-    update_periods
+    update_stats
     # TODO: fix and reenable
     #put_geometry_into_equilibrium(spring_id)
     update_trace_visualization
@@ -78,19 +80,22 @@ class SpringPane
 
   def update_mounted_users
     SimulationRunnerClient.update_mounted_users(mounted_users)
-    update_periods
+    update_stats
     update_dialog if @dialog
     update_trace_visualization
   end
 
-  def update_periods
+  def update_stats
     mounted_users.keys.each do |node_id|
-      period = SimulationRunnerClient.get_period(node_id)
+      stats = SimulationRunnerClient.get_user_stats(node_id)
+      period = stats['period']
       period = period.round(2) if period
       # catch invalid periods
       period ||= 'NaN'
       @user_periods[node_id] = period
-      set_period(node_id, period)
+      @user_max_as[node_id] = stats['max_acceleration'].round(2)
+      @user_max_vs[node_id] = stats['max_velocity'].round(2)
+      set_stats(node_id, stats)
     end
   end
 
@@ -123,7 +128,7 @@ class SpringPane
 
   # dialog logic:
 
-  def set_period(node_id, value)
+  def set_stats(node_id, value)
     @dialog.execute_script("set_period(#{node_id}, #{value})")
   end
 

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -49,8 +49,6 @@ class SpringPane
     # notify simulation runner about changed constants
     SimulationRunnerClient.update_spring_constants(constants_for_springs)
 
-    # update simulation data and visualizations with adjusted results
-    simulate
     update_stats
     # TODO: fix and reenable
     #put_geometry_into_equilibrium(spring_id)
@@ -62,7 +60,6 @@ class SpringPane
 
   def force_vectors=(vectors)
     @force_vectors = vectors
-    simulate
     update_trace_visualization
     play_animation
   end
@@ -91,6 +88,9 @@ class SpringPane
   end
 
   def update_trace_visualization
+    # update simulation data and visualizations with adjusted results
+    simulate
+
     @trace_visualization ||= TraceVisualization.new
     @trace_visualization.reset_trace
     # visualize every node with a mounted user

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -51,7 +51,7 @@ class SpringPane
 
     update_stats
     # TODO: fix and reenable
-    #put_geometry_into_equilibrium(spring_id)
+    # put_geometry_into_equilibrium(spring_id)
     update_trace_visualization
 
 

--- a/src/ui/spring-pane/index.erb
+++ b/src/ui/spring-pane/index.erb
@@ -7,11 +7,6 @@
 </style>
 
 <script type="text/javascript">
-  function set_user_stats(id, period, max_a, max_v) {
-    document.getElementById('period_' + id).placeholder = period;
-    document.getElementById('max_a_' + id).placeholder = max_a;
-    document.getElementById('max_v_' + id).placeholder = max_v;
-  }
   function set_constant(id, value) {
     document.getElementById('spring_constant_' + id).placeholder = value;
     document.getElementById('spring_constant_range_' + id).value = value;
@@ -53,7 +48,12 @@
 <div class="card m-2 p-2">
   <h5 class="card-title">User parameters</h5>
   <div class="card-body">
-    <% mounted_users.each { |node_id, user_force| %>
+    <%
+      mounted_users.each { |node_id, user_force|
+        stats = @user_stats[node_id]
+        digits_precision = 2
+    %>
+
       <h6>#<%= node_id %></h6>
       <div class="row">
         <div class="col-6">
@@ -61,7 +61,7 @@
             <div class="input-group-prepend">
               <span class="input-group-text text-monospace">p</span>
             </div>
-            <input id="period_<%= node_id %>" type="text" placeholder="<%= @user_periods[node_id] %>" readonly class="form-control" style="text-align: right;">
+            <input id="period_<%= node_id %>" type="text" placeholder="<%= stats['period'].round(digits_precision) %>" readonly class="form-control" style="text-align: right;">
             <div class="input-group-append">
               <span class="input-group-text text-monospace">s</span>
             </div>
@@ -85,7 +85,7 @@
             <div class="input-group-prepend">
               <span class="input-group-text text-monospace">a<sub>max</sub></span>
             </div>
-            <input id="max_a_<%= node_id %>" type="text" placeholder="<%= @user_max_as[node_id] %>" readonly class="form-control" style="text-align: right;">
+            <input id="max_a_<%= node_id %>" type="text" placeholder="<%= stats['max_acceleration'].round(digits_precision) %>" readonly class="form-control" style="text-align: right;">
             <div class="input-group-append">
               <span class="input-group-text text-monospace">m/s<sup>2</sup></span>
             </div>
@@ -96,7 +96,7 @@
             <div class="input-group-prepend">
               <span class="input-group-text text-monospace">v<sub>max</sub></span>
             </div>
-            <input id="max_v_<%= node_id %>" type="text" placeholder="<%= @user_max_vs[node_id] %>" readonly class="form-control" style="text-align: right;">
+            <input id="max_v_<%= node_id %>" type="text" placeholder="<%= stats['max_velocity'].round(digits_precision) %>" readonly class="form-control" style="text-align: right;">
             <div class="input-group-append">
               <span class="input-group-text text-monospace">m/s</span>
             </div>

--- a/src/ui/spring-pane/index.erb
+++ b/src/ui/spring-pane/index.erb
@@ -7,8 +7,10 @@
 </style>
 
 <script type="text/javascript">
-  function set_period(id, value) {
-    document.getElementById('period_' + id).placeholder = value;
+  function set_user_stats(id, period, max_a, max_v) {
+    document.getElementById('period_' + id).placeholder = period;
+    document.getElementById('max_a_' + id).placeholder = max_a;
+    document.getElementById('max_v_' + id).placeholder = max_v;
   }
   function set_constant(id, value) {
     document.getElementById('spring_constant_' + id).placeholder = value;
@@ -54,7 +56,7 @@
     <% mounted_users.each { |node_id, user_force| %>
       <h6>#<%= node_id %></h6>
       <div class="row">
-        <div class="col-7">
+        <div class="col-6">
           <div class="input-group mb-3">
             <div class="input-group-prepend">
               <span class="input-group-text text-monospace">p</span>
@@ -65,7 +67,7 @@
             </div>
           </div>
         </div>
-        <div class="col-5">
+        <div class="col-6">
           <div class="input-group mb-3">
             <div class="input-group-prepend">
               <span class="input-group-text text-monospace">m</span>
@@ -73,6 +75,30 @@
             <input id="mass_<%= node_id %>" type="text" placeholder="<%= user_force %>" readonly class="form-control" style="text-align: right;">
             <div class="input-group-append">
               <span class="input-group-text text-monospace">kg</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-6">
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <span class="input-group-text text-monospace">a<sub>max</sub></span>
+            </div>
+            <input id="max_a_<%= node_id %>" type="text" placeholder="<%= @user_max_as[node_id] %>" readonly class="form-control" style="text-align: right;">
+            <div class="input-group-append">
+              <span class="input-group-text text-monospace">m/s<sup>2</sup></span>
+            </div>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <span class="input-group-text text-monospace">v<sub>max</sub></span>
+            </div>
+            <input id="max_v_<%= node_id %>" type="text" placeholder="<%= @user_max_vs[node_id] %>" readonly class="form-control" style="text-align: right;">
+            <div class="input-group-append">
+              <span class="input-group-text text-monospace">m/s</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Extends user params section in the spring ui by max speed and acceleration (and makes sure the information is retrieved correctly from the modelica backend):

<img width="491" alt="image" src="https://user-images.githubusercontent.com/5410949/78132643-65dbd200-741d-11ea-8c33-837553cc46f7.png">
