### PR TITLE
Remember the save/load path and remember spring pane position

### DIFF
--- a/src/tools/export_file_tool.rb
+++ b/src/tools/export_file_tool.rb
@@ -26,7 +26,7 @@ class ExportFileTool < Tool
 
   def export_with_file_dialog(triangle = nil)
     @export_path = Configuration::JSON_PATH if @last_export_path.nil?
-    @export_path = UI.savepanel('Export JSON', @export_path, 'export.json')
+    @export_path = UI.savepanel('Export JSON', @last_export_path, 'export.json')
     @last_export_path = File.dirname(@export_path) unless @export_path.nil?
     animation = @ui.animation_pane.animation_values
     return if @export_path.nil?

--- a/src/tools/export_file_tool.rb
+++ b/src/tools/export_file_tool.rb
@@ -25,8 +25,9 @@ class ExportFileTool < Tool
   end
 
   def export_with_file_dialog(triangle = nil)
-    @export_path = Configuration::JSON_PATH if @export_path.nil?
+    @export_path = Configuration::JSON_PATH if @last_export_path.nil?
     @export_path = UI.savepanel('Export JSON', @export_path, 'export.json')
+    @last_export_path = File.dirname(@export_path) unless @export_path.nil?
     animation = @ui.animation_pane.animation_values
     return if @export_path.nil?
 

--- a/src/tools/import_file_tool.rb
+++ b/src/tools/import_file_tool.rb
@@ -9,14 +9,15 @@ class ImportFileTool < ImportTool
 
   def activate
     super
-    @import_path = if @import_path.nil?
+    @import_path = if @last_loaded_path.nil?
                      Configuration::JSON_PATH
                    else
-                     File.dirname(@import_path)
+                     @last_loaded_path
                    end
     @import_path = UI.openpanel('Open JSON',
                                 @import_path,
                                 'JSON File|*.json;||')
+    @last_loaded_path = File.dirname(@import_path) unless @import_path.nil?
     @path = @import_path
   end
 

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -150,9 +150,8 @@ class SpringPane
       preferences_key: 'com.trussfab.spring_insights',
       width: 250,
       height: 50 + @spring_edges.length * 200,
-      left: 5,
-      top: 5,
-      # max_height: @height
+      left: 500,
+      top: 500,
       style: UI::HtmlDialog::STYLE_DIALOG
     }
 
@@ -161,7 +160,6 @@ class SpringPane
     content = File.read(file_path)
     t = ERB.new(content)
     @dialog.set_html(t.result(binding))
-    @dialog.set_position(500, 500)
     @dialog.show
     register_callbacks
   end


### PR DESCRIPTION
Previously, the saved preference for the ui position was overwritten by a call of set position.

Now, this is removed, which (at least on windows) leads to the window position staying the same when reopening Sketchup. @birneamstiel  Maybe you can check on Mac?

The save/load folders were already saved, but only if you actually load/save something from the folder. That was cleared, when the dialog was canceled instead of choosing something, and the default was used again.
Now, it should always open the folder that the user loaded the last item on. Maybe also check that on Mac thought.