### PR TITLE
Add Mount and Pistons to SpringCylinderVisualization

### DIFF
--- a/src/sketchup_objects/link_entities/spring_cylinder.rb
+++ b/src/sketchup_objects/link_entities/spring_cylinder.rb
@@ -3,10 +3,15 @@ class SpringCylinder < SketchupObject
   attr_reader :material
 
   CYLINDER_RADIUS = 0.5
+  CYLINDER_ALPHA = 1.0
+  THICK_CYLINDER_THICKNESS_RATIO = 2.0
+  THIN_CYLINDER_THICKNESS_RATIO = 1.25
+  PLATE_HEIGHT = 0.5
+  SEGMENT_NUMBER = 24
 
-  def initialize(parent, length, spring_length, spring_diameter, id = nil)
+  def initialize(parent, edge_length, spring_length, spring_diameter, id: nil)
     super(id)
-    @definition = create_cylinder(Geom::Point3d.new, Geom::Vector3d.new(0, 0, 1), length,
+    @definition = create_cylinder(Geom::Point3d.new, Geom::Vector3d.new(0, 0, 1), edge_length,
                                   spring_length / 2, spring_diameter)
     @entity = create_entity
     @parent = parent
@@ -27,42 +32,41 @@ class SpringCylinder < SketchupObject
 
   def change_color(color)
     @entity.material = color
-    @entity.material.alpha = 1.0
+    @entity.material.alpha = CYLINDER_ALPHA
   end
 
   def create_cylinder(center, up_vector, length, fix_plates_offset, spring_diameter)
-    segment_number = 24
     spring_center_position = center + Geometry.scale_vector(up_vector, length / 2)
     definition = Sketchup.active_model.definitions.add("spring_cylinder_#{@id}")
 
     # Add cylinder connecting both nodes (with small diameter)
-    circle_edgearray = definition.entities.add_circle(center, up_vector, CYLINDER_RADIUS, segment_number)
+    circle_edgearray = definition.entities.add_circle(center, up_vector, CYLINDER_RADIUS, SEGMENT_NUMBER)
     face = definition.entities.add_face(circle_edgearray)
     face.pushpull(-length, false)
 
     # Add thin inner piston cylinder
-    circle_edgearray = definition.entities.add_circle(spring_center_position, up_vector, CYLINDER_RADIUS * 1.25,
-                                                      segment_number)
+    circle_edgearray = definition.entities.add_circle(spring_center_position, up_vector,
+                                                      CYLINDER_RADIUS * THIN_CYLINDER_THICKNESS_RATIO, SEGMENT_NUMBER)
     face = definition.entities.add_face(circle_edgearray)
     face.pushpull(-fix_plates_offset, false)
 
     # Add thick inner piston cylinder
     circle_edgearray = definition.entities.add_circle(spring_center_position, up_vector,
-                                                      CYLINDER_RADIUS * 2.0, segment_number)
+                                                      CYLINDER_RADIUS * THICK_CYLINDER_THICKNESS_RATIO, SEGMENT_NUMBER)
     face = definition.entities.add_face(circle_edgearray)
     face.pushpull(fix_plates_offset, false)
 
     # Add fixing plates, restricting spring
-    plate_height = 0.5
     spring_start = spring_center_position + Geometry.scale_vector(up_vector.normalize.reverse!, fix_plates_offset)
     spring_end = spring_center_position + Geometry.scale_vector(up_vector.normalize, fix_plates_offset)
 
-    start_circle_edgearray = definition.entities.add_circle(spring_start, up_vector.reverse, spring_diameter, segment_number)
+    start_circle_edgearray = definition.entities.add_circle(spring_start, up_vector.reverse, spring_diameter,
+                                                            SEGMENT_NUMBER)
     face = definition.entities.add_face(start_circle_edgearray)
-    face.pushpull(plate_height, false)
-    end_circle_edgearray = definition.entities.add_circle(spring_end, up_vector, spring_diameter, segment_number)
+    face.pushpull(PLATE_HEIGHT, false)
+    end_circle_edgearray = definition.entities.add_circle(spring_end, up_vector, spring_diameter, SEGMENT_NUMBER)
     face = definition.entities.add_face(end_circle_edgearray)
-    face.pushpull(plate_height, false)
+    face.pushpull(PLATE_HEIGHT, false)
 
     definition.entities.each do |entity|
       entity.layer = Configuration::ACTUATOR_VIEW

--- a/src/sketchup_objects/link_entities/spring_cylinder.rb
+++ b/src/sketchup_objects/link_entities/spring_cylinder.rb
@@ -2,10 +2,12 @@
 class SpringCylinder < SketchupObject
   attr_reader :material
 
-  def initialize(parent, length, diameter, id = nil)
+  CYLINDER_RADIUS = 0.5
+
+  def initialize(parent, length, spring_length, spring_diameter, id = nil)
     super(id)
-    @definition = create_cylinder(Geom::Point3d.new, Geom::Vector3d.new(0, 0, 1),length, diameter,
-                                  "spring_cylinder_#{id}")
+    @definition = create_cylinder(Geom::Point3d.new, Geom::Vector3d.new(0, 0, 1), length,
+                                  spring_length / 2, spring_diameter)
     @entity = create_entity
     @parent = parent
     persist_entity(type: parent.class.to_s, id: parent.id)
@@ -28,13 +30,40 @@ class SpringCylinder < SketchupObject
     @entity.material.alpha = 1.0
   end
 
-  def create_cylinder(center, up_vector, length, diameter, name)
-    definition = Sketchup.active_model.definitions.add(name)
-    circle_edgearray = definition.entities.add_circle(center,
-                                                      up_vector,
-                                                      diameter, 12)
+  def create_cylinder(center, up_vector, length, fix_plates_offset, spring_diameter)
+    segment_number = 24
+    spring_center_position = center + Geometry.scale_vector(up_vector, length / 2)
+    definition = Sketchup.active_model.definitions.add("spring_cylinder_#{@id}")
+
+    # Add cylinder connecting both nodes (with small diameter)
+    circle_edgearray = definition.entities.add_circle(center, up_vector, CYLINDER_RADIUS, segment_number)
     face = definition.entities.add_face(circle_edgearray)
     face.pushpull(-length, false)
+
+    # Add thin inner piston cylinder
+    circle_edgearray = definition.entities.add_circle(spring_center_position, up_vector, CYLINDER_RADIUS * 1.25,
+                                                      segment_number)
+    face = definition.entities.add_face(circle_edgearray)
+    face.pushpull(-fix_plates_offset, false)
+
+    # Add thick inner piston cylinder
+    circle_edgearray = definition.entities.add_circle(spring_center_position, up_vector,
+                                                      CYLINDER_RADIUS * 2.0, segment_number)
+    face = definition.entities.add_face(circle_edgearray)
+    face.pushpull(fix_plates_offset, false)
+
+    # Add fixing plates, restricting spring
+    plate_height = 0.5
+    spring_start = spring_center_position + Geometry.scale_vector(up_vector.normalize.reverse!, fix_plates_offset)
+    spring_end = spring_center_position + Geometry.scale_vector(up_vector.normalize, fix_plates_offset)
+
+    start_circle_edgearray = definition.entities.add_circle(spring_start, up_vector.reverse, spring_diameter, segment_number)
+    face = definition.entities.add_face(start_circle_edgearray)
+    face.pushpull(plate_height, false)
+    end_circle_edgearray = definition.entities.add_circle(spring_end, up_vector, spring_diameter, segment_number)
+    face = definition.entities.add_face(end_circle_edgearray)
+    face.pushpull(plate_height, false)
+
     definition.entities.each do |entity|
       entity.layer = Configuration::ACTUATOR_VIEW
     end

--- a/src/sketchup_objects/spring_link.rb
+++ b/src/sketchup_objects/spring_link.rb
@@ -5,8 +5,8 @@ require 'src/system_simulation/spring_picker.rb'
 
 # PhysicsLink that behaves like a gas spring
 class SpringLink < ActuatorLink
-  attr_accessor :spring_parameters, :actual_spring_length
-  attr_reader :edge, :initial_spring_length
+  attr_accessor :actual_spring_length
+  attr_reader :edge, :initial_spring_length, :spring_parameters
 
   def initialize(first_node, second_node, edge, spring_parameters: nil, id: nil)
     @initial_edge_length = first_node.hub.entity.bounds.center.vector_to(second_node.hub.entity.bounds.center)
@@ -101,7 +101,7 @@ class SpringLink < ActuatorLink
     add(@first_cylinder)
 
     @second_cylinder = SpringCylinder.new(self, @initial_edge_length, @actual_spring_length,
-                                          @spring_coil_diameter, nil)
+                                          @spring_coil_diameter)
     add(@second_cylinder)
 
     # Update the link_transformation, that we're previously just initialized

--- a/src/sketchup_objects/spring_link.rb
+++ b/src/sketchup_objects/spring_link.rb
@@ -13,7 +13,7 @@ class SpringLink < ActuatorLink
                                      .length.to_f
     @spring_parameters = spring_parameters ? spring_parameters : SpringPicker.instance.get_default_spring
     @actual_spring_length = @spring_parameters[:unstreched_length].m
-    p @actual_spring_length
+    @spring_coil_diameter = @spring_parameters[:coil_diameter].m
     super(first_node, second_node, edge, id: id)
     @first_elongation_length =
       @second_elongation_length = Configuration::MINIMUM_ELONGATION
@@ -23,6 +23,7 @@ class SpringLink < ActuatorLink
   def spring_parameters=(parameters)
     @spring_parameters = parameters
     @actual_spring_length = @spring_parameters[:unstreched_length].m
+    @spring_coil_diameter = @spring_parameters[:coil_diameter].m
     update_link_properties
   end
 
@@ -99,7 +100,8 @@ class SpringLink < ActuatorLink
     @first_cylinder = Spring.new(self, spring_model.definition, nil)
     add(@first_cylinder)
 
-    @second_cylinder = SpringCylinder.new(self, @initial_edge_length, 0.5, nil)
+    @second_cylinder = SpringCylinder.new(self, @initial_edge_length, @actual_spring_length,
+                                          @spring_coil_diameter, nil)
     add(@second_cylinder)
 
     # Update the link_transformation, that we're previously just initialized


### PR DESCRIPTION
This PR adds plates on top and below the spring and pistons (cylinder with different diameters) inside the spring.

Caveats:
- we don't have a offset for that leading to selecting long springs leading to our plates bugging into nodes (we should probably have real, realistic values for the diameter of the plates to take this into account here @robertkovax )
- when animating the whole edge is scaled along it's up vector, that's ok behaviour but for perfect realism we would want to not scale the inner pistons but just translate them (as we do for actuators). That's a bit more complicated since the scaling is done outside of the SpringCylinder definition where we don't have an understanding of the single components the cylinder is consisting of. So maybe we want to divide these different objects (plates, cylinder, plates) into different definitions. But for now I think this is fair...

<img width="423" alt="image" src="https://user-images.githubusercontent.com/5410949/78239422-f843aa80-74dd-11ea-93a7-11c698b36d0e.png">
