### PR TITLE
Small Fixes

### DIFF
--- a/src/configuration/configuration.rb
+++ b/src/configuration/configuration.rb
@@ -162,4 +162,6 @@ module Configuration
   DISTANCE_TO_PLANE_THRESHOLD = 10.0
   # What duration the trace visualization should span if the oscillation is not planar, in seconds.
   NON_PLANAR_TRACE_DURATION = 10
+  # Show fancy oscillation animation when placing springs, will lead to crashes though.
+  PLACE_SPRING_ANIMATIONS = false
 end

--- a/src/sketchup_objects/spring_constant_observer.rb
+++ b/src/sketchup_objects/spring_constant_observer.rb
@@ -9,8 +9,11 @@ class SpringConstantObserver < Sketchup::EntityObserver
     unless text.is_a? Sketchup::Text
       puts "WARNING: SpringConstantObserver attached to a entity which is not a text. This is not intended to work."
     end
-    puts "constant changed: #{text.text}"
-    TrussFab.get_spring_pane.update_constant_for_spring(@spring_id, text.text.to_i)
+
+    if text.valid?
+      puts "constant changed: #{text.text}"
+      TrussFab.get_spring_pane.update_constant_for_spring(@spring_id, text.text.to_i)
+    end
 
   end
 end

--- a/src/sketchup_objects/spring_link.rb
+++ b/src/sketchup_objects/spring_link.rb
@@ -14,7 +14,7 @@ class SpringLink < ActuatorLink
   def initialize(first_node, second_node, edge, spring_parameters: nil, id: nil)
     @initial_edge_length = first_node.hub.entity.bounds.center.vector_to(second_node.hub.entity.bounds.center)
                                      .length.to_f
-    @spring_parameters = spring_parameters ? spring_parameters : SpringPicker.instance.get_default_spring
+    @spring_parameters = spring_parameters ? spring_parameters : SpringPicker.instance.get_default_spring(edge.length.to_m)
     @actual_spring_length = @spring_parameters[:unstreched_length].m
     @spring_coil_diameter = @spring_parameters[:coil_diameter].m
     super(first_node, second_node, edge, id: id)

--- a/src/system_simulation/spring_picker.rb
+++ b/src/system_simulation/spring_picker.rb
@@ -92,7 +92,9 @@ class SpringPicker
     }.max_by{ |line|  line[:unstreched_length] }.to_h
   end
 
-  def get_default_spring
-    get_spring(3500, 0.6)
+  def get_default_spring(length)
+    # TODO: calculate mount_offset
+    mount_offset = 0.1
+    get_spring(3500, length - mount_offset)
   end
 end

--- a/src/tools/delete_tool.rb
+++ b/src/tools/delete_tool.rb
@@ -76,6 +76,7 @@ class DeleteTool < Tool
     # Update springs and mounted users to changed geometry (e.g. a spring is deleted)
     @ui.spring_pane.update_springs
     @ui.spring_pane.update_mounted_users if update_users
+    @ui.spring_pane.notify_model_changed
     view.invalidate
   end
 end

--- a/src/tools/import_file_tool.rb
+++ b/src/tools/import_file_tool.rb
@@ -5,6 +5,7 @@ require 'src/configuration/configuration.rb'
 class ImportFileTool < ImportTool
   def initialize(_ui)
     super
+    @update_springs = true
   end
 
   def activate

--- a/src/tools/import_tool.rb
+++ b/src/tools/import_tool.rb
@@ -74,6 +74,7 @@ class ImportTool < Tool
       @ui.spring_pane.request_compilation
       @ui.spring_pane.update_mounted_users
       @ui.spring_pane.update_springs
+      @ui.spring_pane.update_trace_visualization false
     end
 
     @mouse_input.update_positions(view, x, y)

--- a/src/ui/dialogs/animation_pane.rb
+++ b/src/ui/dialogs/animation_pane.rb
@@ -37,7 +37,7 @@ class AnimationPane
     @dialog = UI::HtmlDialog.new(props)
     file = File.join(File.dirname(__FILE__), HTML_FILE)
     @dialog.set_file(file)
-    @dialog.show
+    #@dialog.show
 
     register_callbacks
     @dialog

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -298,6 +298,7 @@ class SpringPane
       compile
       # Also update trace visualization to provide visual feedback to user
       update_stats
+      update_bode_diagram
       update_dialog if @dialog
       update_trace_visualization true
     end

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -314,8 +314,12 @@ class SpringPane
       weight = value.to_i
       Graph.instance.nodes[node_id].hub.user_weight = weight
       update_mounted_users
+      update_bode_diagram
       update_trace_visualization true
       puts "Update user weight: #{weight}"
+
+      # TODO: probably this is a duplicate call, cleanup this updating the dialog logic
+      update_dialog if @dialog
     end
   end
 

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -73,7 +73,9 @@ class SpringPane
   end
 
   def get_spring(edge, new_constant)
-    @spring_picker.get_spring(new_constant, edge.length.to_m)
+    # TODO: calculate mount_offset
+    mount_offset = 0.1
+    @spring_picker.get_spring(new_constant, edge.length.to_m - mount_offset)
   end
 
   def update_springs

--- a/src/ui/sidebar/index.html
+++ b/src/ui/sidebar/index.html
@@ -80,15 +80,15 @@
       <div>delete</div>
     </button>
 
-    <h6>Add-Ons</h6>
-    <button type="button" class="tool" id="pod_tool">
-      <img src="../trussfab-globals/assets/icons/pod.png" alt="pod">
-      <div>pod</div>
-    </button>
-    <button type="button" class="tool" id="cover_tool">
-      <img src="../trussfab-globals/assets/icons/cover.png" alt="cover">
-      <div>cover</div>
-    </button>
+<!--    <h6>Add-Ons</h6>-->
+<!--    <button type="button" class="tool" id="pod_tool">-->
+<!--      <img src="../trussfab-globals/assets/icons/pod.png" alt="pod">-->
+<!--      <div>pod</div>-->
+<!--    </button>-->
+<!--    <button type="button" class="tool" id="cover_tool">-->
+<!--      <img src="../trussfab-globals/assets/icons/cover.png" alt="cover">-->
+<!--      <div>cover</div>-->
+<!--    </button>-->
     <!-- <h6 hidden="true">Conversion</h6> -->
     <!-- <button type="button" hidden="true" class="tool">
             <img src="../trussfab-globals/assets/icons/surface.png" alt="surface">
@@ -103,19 +103,19 @@
             <img src="../trussfab-globals/assets/icons/stability.png" alt="print bottle counts">
             <div>bottle counts</div>
           </button> -->
-    <h6>Actuator</h6>
-    <button type="button" class="tool" id="actuator_tool">
-      <img src="../trussfab-globals/assets/icons/actuator.png" width="54px" alt="actuator">
-      <div>actuator</div>
-    </button>
-    <button type="button" class="tool" id="generic_physics_link_tool" style="display: none;">
-      <img src="../trussfab-globals/assets/icons/actuator.png" width="54px" alt="generic">
-      <div>generic link</div>
-    </button>
-    <button type="button" class="tool" id="pid_controller_tool" style="display: none;">
-      <img src="../trussfab-globals/assets/icons/actuator.png" width="54px" alt="pid_controller">
-      <div>PID Link</div>
-    </button>
+<!--    <h6>Actuator</h6>-->
+<!--    <button type="button" class="tool" id="actuator_tool">-->
+<!--      <img src="../trussfab-globals/assets/icons/actuator.png" width="54px" alt="actuator">-->
+<!--      <div>actuator</div>-->
+<!--    </button>-->
+<!--    <button type="button" class="tool" id="generic_physics_link_tool" style="display: none;">-->
+<!--      <img src="../trussfab-globals/assets/icons/actuator.png" width="54px" alt="generic">-->
+<!--      <div>generic link</div>-->
+<!--    </button>-->
+<!--    <button type="button" class="tool" id="pid_controller_tool" style="display: none;">-->
+<!--      <img src="../trussfab-globals/assets/icons/actuator.png" width="54px" alt="pid_controller">-->
+<!--      <div>PID Link</div>-->
+<!--    </button>-->
     <!-- <button type="button" class="tool" id="genetic_actuator_placement_tool">
       <img src="../trussfab-globals/assets/icons/auto_act_uist.png" alt="genetic placment">
       <div>auto. act.</div>

--- a/src/utility/project_helper.rb
+++ b/src/utility/project_helper.rb
@@ -90,8 +90,8 @@ module ProjectHelper
     end
 
     unless layers[Configuration::SPRING_INSIGHTS]
-      hub_id_layer = layers.add(Configuration::SPRING_INSIGHTS)
-      hub_id_layer.visible = false
+      spring_insights_layer = layers.add(Configuration::SPRING_INSIGHTS)
+      spring_insights_layer.visible = true
     end
 
     unless layers[Configuration::FORCE_VIEW]


### PR DESCRIPTION
including:
* deleting period visualisation animation (ball pendulum)?
* disable spring tool animations on default (can be activated using the config)
* generally cleaning up the updating of the trace visualizatio logic
* show spring insights layer on default
* cleanup menu / hide trussformers animations panel
* fix common errors that showed up frequently in the console
