### PR TITLE
Make updates in the background and simplify endpoints

### DIFF
--- a/src/configuration/configuration.rb
+++ b/src/configuration/configuration.rb
@@ -3,7 +3,7 @@ require 'src/utility/project_helper.rb'
 module Configuration
 
   SIMULATION_SERVER_PORT = "8085"
-  LAUNCH_SIMULATION_SERVER_WITH_SKETCHUP = false
+  LAUNCH_SIMULATION_SERVER_WITH_SKETCHUP = true
 
   # Sketchup Layers
   LINE_VIEW = 'Link lines'.freeze

--- a/src/julia/src/Server.jl
+++ b/src/julia/src/Server.jl
@@ -3,6 +3,9 @@
 # TODO fix mapping for server and client ids
 # TODO make handling of global variables nicer somehow
 
+# TODO reduce JSON number precision to have smaller json responses and faster parsing time
+# TODO send 500 errors when there is an exception
+
 using HTTP
 using Sockets
 using JSON
@@ -19,44 +22,23 @@ ROUTER = HTTP.Router()
 simulation_fps = 25
 current_simulation_task = nothing
 current_model = nothing
-simulated_model_hash = 0
 get_client_ids = []
 spring_constants_override = nothing
-users = []
 
-# current_model
-
-# using Plots
-# parsed_structure = TrussFab.import_trussfab_json(current_model)
-# sol = TrussFab.run_simulation(parsed_structure, actuation_power=0.0)
-# plot(sol)
-# current_model["spring_constants"]
-# parsed_structure
-
+# --- Actual Simulation ---
 
 function asyncSimulation()
     global current_model
     global simulated_model_hash
     global current_simulation_task
     global client_ids
-    global users
-
-    if hash((current_model, users)) == simulated_model_hash
-        # the previous simulation already addressed this combination of structure and users
-        return
-    end
 
     if spring_constants_override !== nothing
         # TODO implement spring constants override
         @warn "WARNING: There are spring constants that the client set that are not part of the simulation. #NotYetImplemented $(spring_constants_override)"
     end
 
-    simulated_structure_hash = hash((current_model, users))
-
-    this_current_model = deepcopy(current_model)
-    this_current_model["mounted_users"] = users
-
-    parsed_structure = TrussFab.import_trussfab_json(this_current_model)
+    parsed_structure = TrussFab.import_trussfab_json(current_model)
     client_ids = get_prop(parsed_structure, :original_index_keys)
 
     # (optimistically) abort current simulation to free system ressources and obtain lock
@@ -71,79 +53,31 @@ function asyncSimulation()
     nothing
 end
 
-function updateModel(req::HTTP.Request)
-    global current_model
-    current_model = JSON.parse(String(req.body))
-    current_model["mounted_users"] = []
 
-    @info "updated model"
+# --- converting simulation data to json objects ---
 
-    asyncSimulation()
-    return HTTP.Response(200, "ok")
-end
+function simulationResultToCustomTableArray(simulation_result)
+    # TODO make interface nicer with custom type or MetaGraph indexing
+    symbols_generation_for_vertex(vertex_name, variable_name) = ("node_" * vertex_name * "." * variable_name * "[") .* string.(1:3) .* "]"
+    get_symbols(client_ids2) = map(id -> symbols_generation_for_vertex(string(id), "r_0"), client_ids2) |> Iterators.flatten |> Iterators.collect
+    get_header() = vcat("time", get_symbols(client_ids))
+    result = []
 
-HTTP.register!(ROUTER, "POST", "/update_model", updateModel)
-
-function updateSpringConstants(req::HTTP.Request)
-    # set_spring(src_vertex, dst_vertex, k) = set_prop!(current_structure, src_vertex, dst_vertex, :spring_stiffness, k)
-    # TODO implement
-    global spring_constants_override
-    spring_constants_override = JSON.parse(String(req.body))
-    return HTTP.Response(200, "ok")
-end
-HTTP.register!(ROUTER, "POST", "/update_spring_constants", updateSpringConstants)
-
-
-function updateMountedUsers(req::HTTP.Request)
-    global current_model
-    global users
-    # Example Request {"node_id": weight_in_kg }
-    # {"8": 0.12, "9": 50, "10": 0.12, "11": 50}
-    users = []
-
-    for user in JSON.parse(String(req.body))
-        client_node_id::String, weight::Float64 = user
-        push!(users, Dict("id" => parse(Int, client_node_id), "weight" => weight))
-    end
-    @info "updated users"
-
-    asyncSimulation()
-    return HTTP.Response(200, "ok")
-end
-HTTP.register!(ROUTER, "PATCH", "/update_mounted_users", updateMountedUsers)
-
-function getSimulationResult(req::HTTP.Request)
-    global client_ids
-    function simulationResultToCustomTableArray(simulation_result)
-        # TODO make interface nicer with custom type or MetaGraph indexing
-        symbols_generation_for_vertex(vertex_name, variable_name) = ("node_" * vertex_name * "." * variable_name * "[") .* string.(1:3) .* "]"
-        get_symbols(client_ids2) = map(id -> symbols_generation_for_vertex(string(id), "r_0"), client_ids2) |> Iterators.flatten |> Iterators.collect
-        get_header() = vcat("time", get_symbols(client_ids))
-        result = []
-
-        push!(result, get_header())
-        for (i, ts) in enumerate(simulation_result.t)
-            time_sample = []
-            # only get every second triple (those are the positions)
-            for (j, val) in enumerate(simulation_result[i])
-                if (j - 1) % 6 < 3
-                    push!(time_sample, val)
-                end
+    push!(result, get_header())
+    for (i, ts) in enumerate(simulation_result.t)
+        time_sample = []
+        # only get every second triple (those are the positions)
+        for (j, val) in enumerate(simulation_result[i])
+            if (j - 1) % 6 < 3
+                push!(time_sample, val)
             end
-            push!(result, vcat(ts, time_sample))
         end
-        return result
+        push!(result, vcat(ts, time_sample))
     end
-
-    return fetch(current_simulation_task) |>
-        simulationResultToCustomTableArray |>
-        (data) -> JSON.json(Dict("data" => data)) |>
-        (data) ->  HTTP.Response(200, data)
+    return result
 end
-HTTP.register!(ROUTER, "GET", "/get_hub_time_series_with_force_vector", getSimulationResult)
 
-
-function getUserStats(req::HTTP.Request)
+function get_user_stats_object(simulation_result, client_node_id)
     function get_max(array)
         max_value, max_index = findmax(array)
         return Dict("value" => max_value, "index" => max_index)
@@ -152,18 +86,14 @@ function getUserStats(req::HTTP.Request)
     function row_to_response(row)
         return Dict("time" => row[1], "x" => row[2], "y" => row[3], "z" => row[3])
     end
-
-    global client_ids
-    client_node_id = parse(Int, replace(HTTP.URIs.splitpath(req.target)[2], "?" => "")) # /user_stats/10?, get 10
+    
     server_node_id =  findfirst(e -> e == client_node_id, client_ids)
-    # TODO fix index mapping (maybe start doing it properly)
-    simulation_result = fetch(current_simulation_task)
 
     velocities = [simulation_result.t simulation_result[server_node_id*6-2:server_node_id*6, :]']
     acceleration = get_acceleration(velocities, simulation_fps)
     amplitude_length, (amplitude_start, amplitude_end) = get_amplitude(simulation_result, server_node_id)
 
-    response = Dict(
+    return Dict(
         "period" => 1 / get_dominant_frequency(simulation_result, server_node_id),
         "max_velocity" => (velocities |> eachrow .|> norm) |> get_max,
         "time_velocity" => eachrow(velocities) .|> row_to_response,
@@ -171,10 +101,39 @@ function getUserStats(req::HTTP.Request)
         "time_acceleration" => eachrow(acceleration) .|> row_to_response,
         "largest_amplitude" => Dict( "start" => amplitude_start, "end" => amplitude_end, "physical_length" => amplitude_length)
     )
-    @info response["largest_amplitude"]
-    return HTTP.Response(200, JSON.json(response))
 end
-HTTP.register!(ROUTER, "GET", "/get_user_stats/*", getUserStats)
+
+
+# --- endpoints ---
+
+function update_model(req::HTTP.Request)
+    global current_model
+    current_model = JSON.parse(String(req.body))
+
+    @info "updated model"
+
+    asyncSimulation()
+    simulation_result = fetch(current_simulation_task)
+    return HTTP.Response(200, JSON.json(Dict(
+        "data" => simulationResultToCustomTableArray(simulation_result),
+         # c_id := client_node_id
+        "user_stats" => Dict(user["id"] => get_user_stats_object(simulation_result, user["id"]) for user in current_model["mounted_users"])
+    )))
+end
+HTTP.register!(ROUTER, "POST", "/update_model", update_model)
+
+
+function update_spring_constants(req::HTTP.Request)
+    # set_spring(src_vertex, dst_vertex, k) = set_prop!(current_structure, src_vertex, dst_vertex, :spring_stiffness, k)
+    # TODO implement
+    global spring_constants_override
+    spring_constants_override = JSON.parse(String(req.body))
+    return HTTP.Response(200, "ok")
+end
+HTTP.register!(ROUTER, "POST", "/update_spring_constants", update_spring_constants)
+
+
+# --- http server ---
 
 # run warm up in the background such that user can already interact
 # task is compute-bound therefore @async/co-routines wont do

--- a/src/system_simulation/simulation_runner_client.rb
+++ b/src/system_simulation/simulation_runner_client.rb
@@ -4,21 +4,22 @@ require 'net/http'
 require 'uri'
 require_relative 'animation_data_sample.rb'
 
-# SIMULATION_RUNNER_HOST = "http://localhost:#{Configuration::SIMULATION_SERVER_PORT}".freeze
-SIMULATION_RUNNER_HOST = "http://192.168.150.1:8085".freeze
+SIMULATION_RUNNER_HOST = "http://localhost:#{Configuration::SIMULATION_SERVER_PORT}".freeze
 
 class SimulationRunnerClient
-  def self.update_model(json_string, &block)
+  def self.update_model(json_string)
     p "server request: update_model"
-    uri = URI.parse("#{SIMULATION_RUNNER_HOST}/update_model")
 
-    request = Sketchup::Http::Request.new(uri.to_s, Sketchup::Http::POST)
+    request = Sketchup::Http::Request.new("#{SIMULATION_RUNNER_HOST}/update_model", Sketchup::Http::POST)
     request.headers = {'Content-Type' => 'text/json'}
     request.body = json_string.to_s
 
     request.start do |request, response|
       puts "/update_model successful"
-      yield JSON.parse(response.body)
+      json_response = JSON.parse(response.body)
+      timeseries_data = parse_data(json_response["data"])
+      user_stats = json_response["user_stats"]
+      yield timeseries_data, user_stats
     end
   end
 

--- a/src/system_simulation/simulation_runner_client.rb
+++ b/src/system_simulation/simulation_runner_client.rb
@@ -4,21 +4,22 @@ require 'net/http'
 require 'uri'
 require_relative 'animation_data_sample.rb'
 
-SIMULATION_RUNNER_HOST = "http://localhost:#{Configuration::SIMULATION_SERVER_PORT}".freeze
+# SIMULATION_RUNNER_HOST = "http://localhost:#{Configuration::SIMULATION_SERVER_PORT}".freeze
+SIMULATION_RUNNER_HOST = "http://192.168.150.1:8085".freeze
 
 class SimulationRunnerClient
-  def self.update_model(json_string)
+  def self.update_model(json_string, &block)
     p "server request: update_model"
     uri = URI.parse("#{SIMULATION_RUNNER_HOST}/update_model")
-    header = {'Content-Type' => 'text/json'}
 
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.read_timeout = 240
-
-    request = Net::HTTP::Post.new(uri.request_uri, header)
+    request = Sketchup::Http::Request.new(uri.to_s, Sketchup::Http::POST)
+    request.headers = {'Content-Type' => 'text/json'}
     request.body = json_string.to_s
 
-    response = http.request(request)
+    request.start do |request, response|
+      puts "/update_model successful"
+      yield JSON.parse(response.body)
+    end
   end
 
   def self.update_spring_constants(spring_constants)

--- a/src/system_simulation/simulation_runner_client.rb
+++ b/src/system_simulation/simulation_runner_client.rb
@@ -17,9 +17,7 @@ class SimulationRunnerClient
     request.start do |request, response|
       puts "/update_model successful"
       json_response = JSON.parse(response.body)
-      timeseries_data = parse_data(json_response["data"])
-      user_stats = json_response["user_stats"]
-      yield timeseries_data, user_stats
+      yield json_response
     end
   end
 
@@ -115,34 +113,4 @@ class SimulationRunnerClient
     end
 
   end
-
-  # Parses data retrieved from a csv, must contain header at the first index.
-  def self.parse_data(data_array)
-    # parse in which columns the coordinates for each node are stored
-    indices_map = AnimationDataSample.indices_map_from_header(data_array[0])
-
-    # remove header of loaded data
-    data_array.shift
-
-    # parse csv
-    data_samples = []
-    data_array.each do |value|
-      data_samples << AnimationDataSample.from_raw_data(value, indices_map)
-    end
-
-    data_samples
-
-  end
-
-  def self.spring_data_from_graph
-    constants_for_springs = {}
-    spring_links = Graph.instance.edges.values
-                       .select { |edge| edge.link_type == 'spring' }
-                       .map(&:link)
-    spring_links.each do |link|
-      constants_for_springs[link.edge.id] = link.spring_parameters[:k]
-    end
-    constants_for_springs
-  end
-
 end

--- a/src/ui/dialogs/spring_pane.rb
+++ b/src/ui/dialogs/spring_pane.rb
@@ -238,18 +238,6 @@ class SpringPane
     simulate
   end
 
-  # def compile
-  #   Sketchup.active_model.start_operation('compile simulation', true)
-  #   compile_time = Benchmark.realtime do
-  #     SimulationRunnerClient.update_model(
-  #       JsonExport.graph_to_json(nil, [], constants_for_springs, mounted_users)
-  #     )
-  #   end
-  #   Sketchup.active_model.commit_operation
-  #   puts "Compiled the modelica model in #{compile_time.round(2)} seconds."
-  #   update_dialog if @dialog
-  # end
-
   def mounted_users
     mounted_users = {}
     Graph.instance.nodes.each do |node_id, node|
@@ -349,14 +337,6 @@ class SpringPane
       update_dialog if @dialog
     end
     Sketchup.active_model.commit_operation
-    # puts "Compiled the modelica model in #{compile_time.round(2)} seconds."
-    # update_dialog if @dialog
-
-
-    # simulation_time = Benchmark.realtime do
-    #   @simulation_data = SimulationRunnerClient.get_hub_time_series(@force_vectors)
-    # end
-    # puts "Simulated the compiled model in #{simulation_time.round(2)} seconds."
   end
 
   # animation logic:

--- a/src/utility/json_export.rb
+++ b/src/utility/json_export.rb
@@ -6,12 +6,12 @@ require 'src/utility/geometry.rb'
 class JsonExport
   def self.export(path, triangle = nil, animation)
     file = File.open(path, 'w')
-    # TODO: also export spring parameters and mounted users to json
-    file.write(graph_to_json(triangle, animation, {}, mounted_users_to_hash(Graph.instance.nodes)))
+    # TODO: also export spring parameters
+    file.write(graph_to_json(triangle, animation, {}))
     file.close
   end
 
-  def self.graph_to_json(triangle = nil, animation, spring_constants_for_ids, mounted_users)
+  def self.graph_to_json(triangle = nil, animation, spring_constants_for_ids)
     graph = Graph.instance
     json = {distance_unit: 'mm', force_unit: 'N'}
     json[:nodes] = nodes_to_hash(graph.nodes)
@@ -22,7 +22,7 @@ class JsonExport
     end
     json[:spring_constants] = spring_constants_for_ids if spring_constants_for_ids
     json[:standard_surface] = triangle.nodes_ids_towards_user
-    json[:mounted_users] = mounted_users if mounted_users
+    json[:mounted_users] = mounted_users_to_hash(Graph.instance.nodes)
     JSON.pretty_generate(json)
   end
 

--- a/truss_fab.rb
+++ b/truss_fab.rb
@@ -110,8 +110,8 @@ module TrussFab
       @animation_pane
     end
 
-    def compile
-      get_spring_pane.compile
+    def simulate
+      get_spring_pane.simulate
     end
 
   end


### PR DESCRIPTION
Make updates in the background: Using the Sketchup HTTP API instead of Ruby's Net API

simplify endpoints: Basically there should be only one endpoint that receives the structure and responds with the simulation result and all user stats